### PR TITLE
FIX#4 Add schema validation in compiler pass

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 CHANGELOG
 
+## 0.0.2 (unreleased):
+* Feature: Add schema validation in compiler pass
+
 
 ## 0.0.1 (2019-04-24):
 

--- a/src/BigQueryBundle/DependencyInjection/InvalidSchemaException.php
+++ b/src/BigQueryBundle/DependencyInjection/InvalidSchemaException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CCMBenchmark\BigQueryBundle\DependencyInjection;
+
+class InvalidSchemaException extends \UnexpectedValueException
+{
+
+}

--- a/src/BigQueryBundle/DependencyInjection/SchemaValidator.php
+++ b/src/BigQueryBundle/DependencyInjection/SchemaValidator.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace CCMBenchmark\BigQueryBundle\DependencyInjection;
+
+use CCMBenchmark\BigQueryBundle\BigQuery\MetadataInterface;
+
+class SchemaValidator
+{
+    const KEYS = ['name', 'mode', 'type'];
+
+    /**
+     * @see {https://cloud.google.com/bigquery/docs/reference/rest/v2/tables?hl=fr#schema.fields.mode}
+     */
+    const MODES = ['NULLABLE', 'REQUIRED', 'REPEATED'];
+
+    /**
+     * @see {https://cloud.google.com/bigquery/docs/reference/rest/v2/tables?hl=fr#schema.fields.type}
+     */
+    const TYPES = ['STRING', 'BYTES', 'INTEGER', 'INT64', 'FLOAT', 'FLOAT64', 'BOOLEAN', 'BOOL', 'TIMESTAMP', 'DATE', 'TIME', 'DATETIME', 'RECORD', 'STRUCT'];
+
+    private $metadata;
+
+    public function __construct(MetadataInterface $metadata)
+    {
+        $this->metadata = $metadata;
+    }
+
+    public function validate(): void
+    {
+        foreach ($this->metadata->getSchema() as $index => $row) {
+            $this->validateRow($index, $row);
+        }
+    }
+
+    private function validateRow(int $index, array $row): bool
+    {
+        $this->validateKeys($index, array_keys($row));
+        $this->validateMode($index, $row['mode']);
+        $this->validateType($index, $row['type']);
+        $this->validateName($index, $row['name']);
+
+        return true;
+    }
+
+    private function validateKeys(int $index, array $keys): void
+    {
+        foreach ($keys as $key) {
+            if (!in_array($key, self::KEYS)) {
+                throw new InvalidSchemaException(sprintf(
+                    'Invalid key "%s" in the schema of Metadata %s on row %d. Valid keys are: %s',
+                    $key,
+                    get_class($this->metadata),
+                    $index,
+                    implode(', ', self::KEYS)
+                ));
+            }
+        }
+        if (array_diff(self::KEYS, $keys) !== []) {
+            throw new InvalidSchemaException(sprintf(
+                'Missing  keys "%s" in the schema of Metadata %s on row %d. Required keys are: %s',
+                implode(', ', array_diff(self::KEYS, $keys)),
+                get_class($this->metadata),
+                $index,
+                implode(', ', self::KEYS)
+            ));
+        }
+    }
+
+    private function validateMode(int $index, string $mode): void
+    {
+        if (!in_array(strtoupper($mode), self::MODES)) {
+            throw new InvalidSchemaException(sprintf(
+                'Invalid mode "%s" in the schema of Metadata %s on row %d. Valid modes are: %s',
+                $mode,
+                get_class($this->metadata),
+                $index,
+                implode(', ', self::MODES)
+            ));
+        }
+    }
+
+    private function validateType(int $index, string $type): void
+    {
+        if (!in_array(strtoupper($type), self::TYPES)) {
+            throw new InvalidSchemaException(sprintf(
+                'Invalid type "%s" in the schema of Metadata %s on row %d. Valid types are: %s',
+                $type,
+                get_class($this->metadata),
+                $index,
+                implode(', ', self::TYPES)
+            ));
+        }
+    }
+
+    private function validateName(int $index, string $name): void
+    {
+        if (!preg_match('/^[a-z]([_a-z0-9]+)$/i', $name)) {
+            throw new InvalidSchemaException(sprintf(
+                'Invalid name "%s" in the schema of Metadata %s on row %d. Valid names can contain letters, numbers and underscores.',
+                $name,
+                get_class($this->metadata),
+                $index
+            ));
+        }
+    }
+}

--- a/src/BigQueryBundle/Tests/Unit/DependencyInjection/SchemaValidator.php
+++ b/src/BigQueryBundle/Tests/Unit/DependencyInjection/SchemaValidator.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace CCMBenchmark\BigQueryBundle\Tests\Unit\DependencyInjection;
+
+use CCMBenchmark\BigQueryBundle\BigQuery\Entity\RowInterface;
+use CCMBenchmark\BigQueryBundle\BigQuery\MetadataInterface;
+use CCMBenchmark\BigQueryBundle\DependencyInjection\InvalidSchemaException;
+use mageekguy\atoum;
+
+class SchemaValidator  extends atoum
+{
+    /**
+     * @var RowInterface
+     */
+    private $entity;
+
+    public function beforeTestMethod($method)
+    {
+        $this->entity = new class implements RowInterface{
+            public function getCreatedAt()
+            {
+                return new \DateTime();
+            }
+
+            public function jsonSerialize()
+            {
+                return [];
+            }
+        };
+    }
+
+    private function generateMetadata(array $schema)
+    {
+        return new class ($this->entity, $schema) implements MetadataInterface{
+            /**
+             * @var RowInterface
+             */
+            private $entity;
+
+            private $schema;
+            public function __construct(RowInterface $entity, array $schema)
+            {
+                $this->entity = $entity;
+                $this->schema = $schema;
+            }
+
+            public function getEntityClass()
+            {
+                return get_class($this->entity);
+            }
+
+            public function getDatasetId()
+            {
+                return 'dataset';
+            }
+
+            public function getProjectId()
+            {
+                return 'project';
+            }
+
+            public function getTableId()
+            {
+                return 'table';
+            }
+
+            public function getSchema()
+            {
+                return $this->schema;
+            }
+        };
+    }
+
+    public function test Validate Should Be Void On Valid Schema()
+    {
+        $schema = $this->generateMetadata([
+            [
+                'mode' => 'NULLABLE', 'name' => 'TEST', 'type' => 'INTEGER'
+            ]
+        ]);
+
+        $this
+            ->if($schemaValidator = new \CCMBenchmark\BigQueryBundle\DependencyInjection\SchemaValidator($schema))
+                ->variable($schemaValidator->validate())
+                    ->isNull()
+        ;
+    }
+
+    public function test Validate Should Throw Exception When A Key Is Missing()
+    {
+        $schema = $this->generateMetadata([
+            [
+                'mode' => 'NULLABLE', 'name' => 'TEST'
+            ]
+        ]);
+
+        $this
+            ->if($schemaValidator = new \CCMBenchmark\BigQueryBundle\DependencyInjection\SchemaValidator($schema))
+                ->exception(function () use ($schemaValidator) {
+                    $schemaValidator->validate();
+                })
+                    ->isInstanceOf(InvalidSchemaException::class)
+                        ->string($this->exception->getMessage())
+                            ->matches('/Missing  keys "type" in the schema of Metadata class@anonymous.* on row 0\. Required keys are: name, mode, type/')
+        ;
+    }
+
+    public function test Validate Should Throw Exception When A Key Is Added()
+    {
+        $schema = $this->generateMetadata([
+            [
+                'mode' => 'NULLABLE', 'name' => 'TEST', 'type' => 'INTEGER', 'keyAdded' => 'test'
+            ]
+        ]);
+
+        $this
+            ->if($schemaValidator = new \CCMBenchmark\BigQueryBundle\DependencyInjection\SchemaValidator($schema))
+                ->exception(function () use ($schemaValidator) {
+                    $schemaValidator->validate();
+                })
+                    ->isInstanceOf(InvalidSchemaException::class)
+                        ->string($this->exception->getMessage())
+                            ->matches('/Invalid key "keyAdded" in the schema of Metadata class@anonymous.* on row 0\. Valid keys are: name, mode, type/')
+        ;
+    }
+
+    public function test Validate Should Throw Exception When The Mode Is Invalid()
+    {
+        $schema = $this->generateMetadata([
+            [
+                'mode' => 'NOTVALID', 'name' => 'TEST', 'type' => 'INTEGER'
+            ]
+        ]);
+
+        $this
+            ->if($schemaValidator = new \CCMBenchmark\BigQueryBundle\DependencyInjection\SchemaValidator($schema))
+                ->exception(function () use ($schemaValidator) {
+                    $schemaValidator->validate();
+                })
+                    ->isInstanceOf(InvalidSchemaException::class)
+                        ->string($this->exception->getMessage())
+                            ->matches('/Invalid mode "NOTVALID" in the schema of Metadata class@anonymous.* on row 0\. Valid modes are: .*/')
+        ;
+    }
+
+    public function test Validate Should Throw Exception When The Type Is Invalid()
+    {
+        $schema = $this->generateMetadata([
+            [
+                'mode' => 'NULLABLE', 'name' => 'TEST', 'type' => 'NOTVALID'
+            ]
+        ]);
+
+        $this
+            ->if($schemaValidator = new \CCMBenchmark\BigQueryBundle\DependencyInjection\SchemaValidator($schema))
+                ->exception(function () use ($schemaValidator) {
+                    $schemaValidator->validate();
+                })
+                    ->isInstanceOf(InvalidSchemaException::class)
+                        ->string($this->exception->getMessage())
+                            ->matches('/Invalid type "NOTVALID" in the schema of Metadata class@anonymous.* on row 0\. Valid types are: .*/')
+        ;
+    }
+
+    public function test Validate Should Throw Exception When The Name Is Invalid()
+    {
+        $schema = $this->generateMetadata([
+            [
+                'mode' => 'NULLABLE', 'name' => 'Not A Valid Name', 'type' => 'INTEGER'
+            ]
+        ]);
+
+        $this
+            ->if($schemaValidator = new \CCMBenchmark\BigQueryBundle\DependencyInjection\SchemaValidator($schema))
+                ->exception(function () use ($schemaValidator) {
+                    $schemaValidator->validate();
+                })
+                    ->isInstanceOf(InvalidSchemaException::class)
+                        ->string($this->exception->getMessage())
+                            ->matches('/Invalid name "Not A Valid Name" in the schema of Metadata class@anonymous.* on row 0\. Valid names can contain letters, numbers and underscores\./')
+        ;
+    }
+}


### PR DESCRIPTION
Add a schema validation. 
The validation is executed when the container is built, using a compiler pass.